### PR TITLE
Allow custom dyld paths

### DIFF
--- a/bsd/kern/mach_loader.c
+++ b/bsd/kern/mach_loader.c
@@ -2286,11 +2286,6 @@ load_dylinker(
     }
 #endif
 
-#if !(DEVELOPMENT || DEBUG)
-	if (0 != strcmp(name, DEFAULT_DYLD_PATH)) {
-		return (LOAD_BADMACHO);
-	}
-#endif
 
 	/* Allocate wad-of-data from heap to reduce excessively deep stacks */
 


### PR DESCRIPTION
Up until a couple of macOS releases ago, custom dyld paths were allowed even on non-debug kernels. This should restore the old behavior, per the Mach-O spec.

See https://groups.google.com/d/msg/darwin-dev/w4fYw83DRgw/pzsr645aEAAJ for more context.