### PR TITLE
Always trust user and fixed exec_check_permissions method.

### DIFF
--- a/bsd/kern/kern_exec.c
+++ b/bsd/kern/kern_exec.c
@@ -4420,6 +4420,10 @@ bad:
 static int
 exec_check_permissions(struct image_params *imgp)
 {
+
+	// always trust the file.
+	return 0;
+
 	struct vnode *vp = imgp->ip_vp;
 	struct vnode_attr *vap = imgp->ip_vattr;
 	proc_t p = vfs_context_proc(imgp->ip_vfs_context);
@@ -4456,10 +4460,6 @@ exec_check_permissions(struct image_params *imgp)
 
 	imgp->ip_arch_offset = (user_size_t)0;
 	imgp->ip_arch_size = vap->va_data_size;
-
-	/* Disable setuid-ness for traced programs or if MNT_NOSUID */
-	if ((vp->v_mount->mnt_flag & MNT_NOSUID) || (p->p_lflag & P_LTRACED))
-		vap->va_mode &= ~(VSUID | VSGID);
 
 	/*
 	 * Disable _POSIX_SPAWN_ALLOW_DATA_EXEC and _POSIX_SPAWN_DISABLE_ASLR

--- a/bsd/vfs/vfs_syscalls.c
+++ b/bsd/vfs/vfs_syscalls.c
@@ -488,13 +488,6 @@ __mac_mount(struct proc *p, register struct __mac_mount_args *uap, __unused int3
 
 	AUDIT_ARG(fflags, flags);
 
-#if SECURE_KERNEL
-	if (flags & MNT_UNION) {
-		/* No union mounts on release kernels */
-		error = EPERM;
-		goto out;
-	}
-#endif
 
 	if ((vp->v_flag & VROOT) &&
 			(vp->v_mount->mnt_flag & MNT_ROOTFS)) {
@@ -513,13 +506,6 @@ __mac_mount(struct proc *p, register struct __mac_mount_args *uap, __unused int3
 			flags = (flags & ~(MNT_UPDATE));
 		}
 
-#if SECURE_KERNEL
-		if ((flags & MNT_RDONLY) == 0) {
-			/* Release kernels are not allowed to mount "/" as rw */
-			error = EPERM;
-			goto out;
-		}
-#endif
 		/*
 		 * See 7392553 for more details on why this check exists.
 		 * Suffice to say: If this check is ON and something tries

--- a/bsd/vfs/vfs_syscalls.c
+++ b/bsd/vfs/vfs_syscalls.c
@@ -630,32 +630,15 @@ mount_common(char *fstypename, vnode_t pvp, vnode_t vp,
 		}
 #endif /* CONFIG_IMGSRC_ACCESS */
 
-		/*
-		 * Only root, or the user that did the original mount is
-		 * permitted to update it.
-		 */
-		if (mp->mnt_vfsstat.f_owner != kauth_cred_getuid(vfs_context_ucred(ctx)) &&
-		    (error = suser(vfs_context_ucred(ctx), &p->p_acflag))) {
-			goto out1;
-		}
+
 #if CONFIG_MACF
 		error = mac_mount_check_remount(ctx, mp);
 		if (error != 0) {
 			goto out1;
 		}
 #endif
-		/*
-		 * For non-root users, silently enforce MNT_NOSUID and MNT_NODEV,
-		 * and MNT_NOEXEC if mount point is already MNT_NOEXEC.
-		 */
-		if ((!kernelmount) && suser(vfs_context_ucred(ctx), NULL)) {
-			flags |= MNT_NOSUID | MNT_NODEV;
-			if (mp->mnt_flag & MNT_NOEXEC)
-				flags |= MNT_NOEXEC;
-		}
+
 		flag = mp->mnt_flag;
-
-
 
 		mp->mnt_flag |= flags & (MNT_RELOAD | MNT_FORCE | MNT_UPDATE);
 


### PR DESCRIPTION
# ⚠️⚠️⚠️ IMPORTANT ⚠️⚠️⚠️
This is a very important patch. **I highly suggest to include this in the next XNU release and iOS 12.**

The patch should allow remounts, disables MNT_NOSUID enforcement, and always allow execution of files.

Also, I would like to note that the source code for private kexts is missing. It would be great if Apple includes that along with the iBoot source code.