### PR TITLE
IOSharedDataQueue does not wrap around if the last entry fits perfectly into the queue.

### DIFF
--- a/iokit/Kernel/IOSharedDataQueue.cpp
+++ b/iokit/Kernel/IOSharedDataQueue.cpp
@@ -175,7 +175,7 @@ IODataQueueEntry * IOSharedDataQueue::peek()
         UInt32              headOffset  = dataQueue->head;
         UInt32              queueSize   = getQueueSize();
 
-        if (headOffset >= queueSize) {
+        if (headOffset > queueSize) {
             return NULL;
         }
 


### PR DESCRIPTION
If one entry fits perfectly into the queue (no room left between the entry and end of the queue), calling peek will always return NULL as this check `headOffset >= queueSize` is wrong.
The check should be `headOffset > queueSize`. In case of equality between the two variables, `headOffset` should be given the chance to wrap to the beginning of the queue.
It is important to note that dequeue function has the right check. I tested it and I was able to get a NULL (fail) from the peek function, but a successful dequeue call.
This pull request fix the issue. 