### PR TITLE
Fix kextload link error on MacOS < 10.13 with build target < 10.13

### DIFF
--- a/osfmk/libsa/string.h
+++ b/osfmk/libsa/string.h
@@ -98,6 +98,8 @@ extern void	bzero(void *, size_t);
 #include <san/memintrinsics.h>
 #endif
 
+#include <AvailabilityMacros.h>
+
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_13
 /* older deployment target */
 #elif defined(KASAN) || (defined (_FORTIFY_SOURCE) && _FORTIFY_SOURCE == 0)


### PR DESCRIPTION
```
// NO PREVIOUS INCLUDE


#include <libkern/libkern.h>

int foo()
{
 // Macro expands to ___builtin___strncpy_chk here!!!
    strncpy(0,0,0);
}
```

```
// NO PREVIOUS INCLUDE

#include <AvailabilityMacros.h>
#include <libkern/libkern.h>

int foo()
{
 // default strncpy function here
    strncpy(0,0,0);
}
```