### PR TITLE
Avoid dropping audit records when kernel is busy

### DIFF
--- a/bsd/security/audit/audit_pipe.c
+++ b/bsd/security/audit/audit_pipe.c
@@ -465,20 +465,14 @@ audit_pipe_append(struct audit_pipe *ap, void *record, u_int record_len)
 		return;
 	}
 
-	ape = malloc(sizeof(*ape), M_AUDIT_PIPE_ENTRY, M_NOWAIT | M_ZERO);
+	ape = malloc(sizeof(*ape) + record_len, M_AUDIT_PIPE_ENTRY, M_WAITOK | M_ZERO);
 	if (ape == NULL) {
 		ap->ap_drops++;
 		audit_pipe_drops++;
 		return;
 	}
-
-	ape->ape_record = malloc(record_len, M_AUDIT_PIPE_ENTRY, M_NOWAIT);
-	if (ape->ape_record == NULL) {
-		free(ape, M_AUDIT_PIPE_ENTRY);
-		ap->ap_drops++;
-		audit_pipe_drops++;
-		return;
-	}
+	
+	ape->ape_record = ape + sizeof(*ape);
 
 	bcopy(record, ape->ape_record, record_len);
 	ape->ape_record_len = record_len;


### PR DESCRIPTION
It's okay to lose audit records if the pipe is full (line 462) because that scenario can be handled by the client in almost all cases. When the kernel is busy, however, audit records are being dropped immediately and the audit trail is compromised in that coherence between data before and after dropping is potentially broken. This seems like a big no-no for the single performant security mechanism available from user space on macOS.

This PR comprises two changes.

1. Allow malloc to wait if the memory manager is busy.
2. Do the memory allocation for audit records in one chunk to minimize wait time.

In case 1. is not feasible in the kernel (I am not an expert), at least 2. reduces the chance to experience a drop by 50% (per call).