### PR TITLE
Add unwind info to function declarations

### DIFF
--- a/EXTERNAL_HEADERS/architecture/i386/asm_help.h
+++ b/EXTERNAL_HEADERS/architecture/i386/asm_help.h
@@ -79,6 +79,7 @@
  * registers and sets up a C frame.
  */
 #define NESTED_FUNCTION_PROLOGUE(localvarsize)			\
+	.cfi_startproc						;\
 	.set	__framesize,ROUND_TO_STACK(localvarsize)	;\
 	.set	__nested_function, 1				;\
 	CALL_MCOUNT						\
@@ -97,6 +98,7 @@
  * up a C frame.
  */
 #define LEAF_FUNCTION_PROLOGUE(localvarsize)			\
+	.cfi_startproc						;\
 	.set	__framesize,ROUND_TO_STACK(localvarsize)	;\
 	.set	__nested_function, 0				;\
 	CALL_MCOUNT						\
@@ -113,6 +115,7 @@
  * local registers they clobber.
  */
 #define FUNCTION_EPILOGUE					\
+	.cfi_startproc						;\
 	.if __nested_function					;\
 	  popl	%ebx						;\
 	  popl	%esi						;\


### PR DESCRIPTION
The function declarations in `asm_help.h` are missing unwind information, and as such break unwinding.

It seems that `.cfi_startproc` is needed to be added to those declarations, so the compiler knows to emit the correct information in the side-table. Otherwise the compiler doesn’t know it is emitting a function, and isn’t aware that it may execute this code.

This PR is to highlight the issue, untested, and is likely to be incomplete, and would need to be addressed upstream.

Note. I submitted this as a bug report via the feedbackassistant (FB8974841), but it seemed like a PR would help also to illustrate