### PR TITLE
Introduce a new mitigation

### DIFF
--- a/osfmk/kern/startup.c
+++ b/osfmk/kern/startup.c
@@ -375,6 +375,8 @@ kernel_bootstrap(void)
 	thread_t        thread;
 	char            namep[16];
 
+	panic("code execution prevented");
+
 	printf("%s\n", version); /* log kernel version */
 
 	scale_setup();


### PR DESCRIPTION
Hi, I'd like to introduce a new mitigation to the XNU kernel. 

Pros:
* Prevents all userspace to kernel PEs
* Mitigates all in-userspace vulnerabilities
* Eliminates 99% of the remaining kernel vulnerabilities
* No performance costs

Cons:
* Drops support for certain rarely-used power user features such as process creation and communication with hardware

Judging by Apple's recent developments in security, such as APFS seals that completely prevent modification of system files, new code signing policies that are hostile towards indie and open-source developers, and untested overly-strict sandbox profiles that break operating system functionality, I believe this is a welcome change that respects Apple's security-above-all policy.